### PR TITLE
Return prech to \0 after complete sequence

### DIFF
--- a/ch05/ex5_12.cpp
+++ b/ch05/ex5_12.cpp
@@ -19,7 +19,7 @@ int main()
                 ++eCnt;
                 break;
             case 'i':
-                if (prech == 'f') ++fiCnt;
+                if (prech == 'f') ++fiCnt,prech='\0';
             case 'I':
                 ++iCnt;
                 break;
@@ -41,10 +41,11 @@ int main()
                 ++newLineCnt;
                 break;
             case 'f':
-                if (prech == 'f') ++ffCnt;
+                if (prech == 'f') ++ffCnt,prech='\0';
+                else prech='f';
                 break;
             case 'l':
-                if (prech == 'f') ++flCnt;
+                if (prech == 'f') ++flCnt,prech='\0';
                 break;
         }
         prech = ch;


### PR DESCRIPTION
Without this, the f will remain on hold and affect the next insertion (i,f, and l alone will increase the counter)